### PR TITLE
Add key_required case

### DIFF
--- a/apps/snarl/src/snarl_tcp_handler.erl
+++ b/apps/snarl/src/snarl_tcp_handler.erl
@@ -210,7 +210,9 @@ message({user, auth, Realm, User, Pass, OTP}, State) when
                   {error, not_found};
               {ok, UUID}  ->
                   {ok, Token} = snarl_token:add(Realm, UUID),
-                  {ok, {token, Token}}
+                  {ok, {token, Token}};
+              key_required ->
+                  {error, not_found}
           end,
     {reply,
      Res,


### PR DESCRIPTION
If a user tries to login without a mfa key when they have one in the db it should fail nicely